### PR TITLE
Adjusted tests for checking translation overwriting

### DIFF
--- a/src/test/java/resources/features/PaymentMethodsTests.feature
+++ b/src/test/java/resources/features/PaymentMethodsTests.feature
@@ -202,7 +202,6 @@ Feature: Payment methods
       | SUCCESS    | "Payment has been successfully processed" | green |
     Examples:
       | actionCode | paymentStatusMessage         | color  |
-      | ERROR      | "An error occurred"           | red    |
       | CANCEL     | "Payment has been cancelled" | yellow |
 
   @fullTest @walletTest @appleTest @mockData
@@ -312,17 +311,15 @@ Feature: Payment methods
       | de_DE    |
 
   @fullTest @translations
-  Scenario Outline: Visa Checkout - checking "Error" status translation for <language>
+  Scenario Outline: Visa Checkout - check translation overwriting mechanism
     When User changes page language to <language>
     And User chooses Visa Checkout as payment method - response set to ERROR
-    Then User will see information about "Error" payment status translated into <language>
+    Then User will see notification frame with message: "Wystąpił błąd"
+    And User will see that notification frame has "red" color
   @smokeTest
     Examples:
       | language |
       | fr_FR    |
-    Examples:
-      | language |
-      | de_DE    |
 
   @fullTest @translations
   Scenario Outline: ApplePay - checking translation for "Payment has been cancelled" status for <language>


### PR DESCRIPTION
As we agreed with Grzesiek, "An error occured" message will be overwrite to "Wystapił błąd" in order to check translation overwriting mechanism. 
Pipeline fails until https://securetrading.atlassian.net/browse/STJS-291 will be on develop.
So, we can merge this branch, after that Grzesiek merge his branch into develop and next I will re run tests from this branch (master)  :)
