### PR TITLE
Fix tests for https://github.com/SecureTrading/js-payments/pull/736

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=bugfix/ST-453-block-form-after-payment
+ARG CODE_VERSION=bugfix-ST-453-block-form-after-payment
 ARG CODE_REPO=js-payments
 FROM securetrading1/${CODE_REPO}:${CODE_VERSION}
 ARG CODE_REPO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=develop
+ARG CODE_VERSION=bugfix/ST-453-block-form-after-payment
 ARG CODE_REPO=js-payments
 FROM securetrading1/${CODE_REPO}:${CODE_VERSION}
 ARG CODE_REPO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=bugfix-ST-453-block-form-after-payment
+ARG CODE_VERSION=develop
 ARG CODE_REPO=js-payments
 FROM securetrading1/${CODE_REPO}:${CODE_VERSION}
 ARG CODE_REPO

--- a/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
+++ b/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
@@ -371,7 +371,7 @@ public class PaymentPage extends BasePage {
                 checkIfMerchantFieldIsHighlighted(fieldType));
     }
 
-    public void validateIfElementIsDisabledAfterPayment(String formStatus, FieldType fieldType) {
+    public void validateIfElementIsEnabledAfterPayment(String formStatus, FieldType fieldType) {
         PicoContainerHelper.updateInContainer(StoredElement.errorMessage,
                 fieldType.toString() + " should be enabled but it isn't ");
          if (formStatus == "enabled") {

--- a/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
+++ b/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
@@ -374,7 +374,7 @@ public class PaymentPage extends BasePage {
     public void validateIfElementIsDisabledAfterPayment(String formStatus, FieldType fieldType) {
         PicoContainerHelper.updateInContainer(StoredElement.errorMessage,
                 fieldType.toString() + " should be enabled but it isn't ");
-         if (formStatus === "enabled") {
+         if (formStatus == "enabled") {
               Assert.assertTrue(PicoContainerHelper.getFromContainer(StoredElement.errorMessage, String.class),
                          checkIfElementIsEnabled(fieldType));
          } else {

--- a/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
+++ b/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
@@ -373,7 +373,7 @@ public class PaymentPage extends BasePage {
 
     public void validateIfElementIsEnabledAfterPayment(String formStatus, FieldType fieldType) {
         PicoContainerHelper.updateInContainer(StoredElement.errorMessage,
-                fieldType.toString() + " should be enabled but it isn't ");
+                fieldType.toString() + " should be "+ formStatus +" but it isn't ");
          if (formStatus == "enabled") {
               Assert.assertTrue(PicoContainerHelper.getFromContainer(StoredElement.errorMessage, String.class),
                          checkIfElementIsEnabled(fieldType));

--- a/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
+++ b/src/test/java/com/SecureTrading/pageobjects/PaymentPage.java
@@ -371,11 +371,17 @@ public class PaymentPage extends BasePage {
                 checkIfMerchantFieldIsHighlighted(fieldType));
     }
 
-    public void validateIfElementIsEnabledAfterPayment(FieldType fieldType) {
+    public void validateIfElementIsDisabledAfterPayment(String formStatus, FieldType fieldType) {
         PicoContainerHelper.updateInContainer(StoredElement.errorMessage,
                 fieldType.toString() + " should be enabled but it isn't ");
-        Assert.assertTrue(PicoContainerHelper.getFromContainer(StoredElement.errorMessage, String.class),
-                checkIfElementIsEnabled(fieldType));
+         if (formStatus === "enabled") {
+              Assert.assertTrue(PicoContainerHelper.getFromContainer(StoredElement.errorMessage, String.class),
+                         checkIfElementIsEnabled(fieldType));
+         } else {
+              Assert.assertFalse(PicoContainerHelper.getFromContainer(StoredElement.errorMessage, String.class),
+                         checkIfElementIsEnabled(fieldType));
+         }
+
     }
 
     public void validateIfFieldIsDisabled(FieldType fieldType, boolean fieldInIframe) {

--- a/src/test/java/com/SecureTrading/stepdefs/PaymentPageSteps.java
+++ b/src/test/java/com/SecureTrading/stepdefs/PaymentPageSteps.java
@@ -237,17 +237,17 @@ public class PaymentPageSteps {
         stubSTRequestType(fieldType.getMockJson(), RequestType.THREEDQUERY);
     }
 
-    @Then("^User will see that Submit button is enabled after payment$")
-    public void userWillSeeThatSubmitButtonIsEnabledAfterPayment() throws InterruptedException {
+    @Then("^User will see that Submit button is (.*) after payment$")
+    public void userWillSeeThatSubmitButtonIsDisabledAfterPayment(String formStatus) throws InterruptedException {
         paymentPage.validateIfNotificationFrameIsDisplayed();
-        paymentPage.validateIfElementIsEnabledAfterPayment(FieldType.SUBMIT_BUTTON);
+        paymentPage.validateIfElementIsEnabledAfterPayment(formStatus, FieldType.SUBMIT_BUTTON);
     }
 
-    @And("^User will see that all input fields are enabled$")
-    public void userWillSeeThatAllInputFieldsAreEnabled() {
-        paymentPage.validateIfElementIsEnabledAfterPayment(FieldType.CARD_NUMBER);
-        paymentPage.validateIfElementIsEnabledAfterPayment(FieldType.CVC);
-        paymentPage.validateIfElementIsEnabledAfterPayment(FieldType.EXPIRY_DATE);
+    @And("^User will see that all input fields are (.*)$")
+    public void userWillSeeThatAllInputFieldsAreDisabled(String formStatus) {
+        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.CARD_NUMBER);
+        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.CVC);
+        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.EXPIRY_DATE);
     }
 
     @When("^User changes page language to ([^\"]*)$")

--- a/src/test/java/com/SecureTrading/stepdefs/PaymentPageSteps.java
+++ b/src/test/java/com/SecureTrading/stepdefs/PaymentPageSteps.java
@@ -245,9 +245,9 @@ public class PaymentPageSteps {
 
     @And("^User will see that all input fields are (.*)$")
     public void userWillSeeThatAllInputFieldsAreDisabled(String formStatus) {
-        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.CARD_NUMBER);
-        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.CVC);
-        paymentPage.validateIfElementIsDisabledAfterPayment(formStatus, FieldType.EXPIRY_DATE);
+        paymentPage.validateIfElementIsEnabledAfterPayment(formStatus, FieldType.CARD_NUMBER);
+        paymentPage.validateIfElementIsEnabledAfterPayment(formStatus, FieldType.CVC);
+        paymentPage.validateIfElementIsEnabledAfterPayment(formStatus, FieldType.EXPIRY_DATE);
     }
 
     @When("^User changes page language to ([^\"]*)$")

--- a/src/test/java/resources/features/PaymentMethodsTests.feature
+++ b/src/test/java/resources/features/PaymentMethodsTests.feature
@@ -230,15 +230,15 @@ Feature: Payment methods
     When User fills payment form with credit card number "4000000000001000", expiration date "12/22" and cvc "123"
     And THREEDQUERY response set to NOT_ENROLLED_N
     And User clicks Pay button - AUTH response set to <actionCode>
-    Then User will see that Submit button is enabled after payment
-    And User will see that all input fields are enabled
+    Then User will see that Submit button is <formStatus> after payment
+    And User will see that all input fields are <formStatus>
   @smokeTest
     Examples:
-      | actionCode |
-      | OK         |
+      | actionCode | formStatus   |
+      | OK         | disabled |
     Examples:
-      | actionCode |
-      | DECLINE    |
+      | actionCode | formStatus |
+      | DECLINE    | enabled |
 
   @baseConfig @fullTest @translations
   Scenario Outline: Checking translations of labels and fields error for <language>


### PR DESCRIPTION
Fix tests for https://github.com/SecureTrading/js-payments/pull/736 after change to the behavour:

1) Form will now be permanently blocked after successful payment (can't process two transactions with the same payment form)
2) Form button will remain disabled after successful payment but display "Pay"
3) Success message will remain indefinitely (all other messages will keep current behaviour of disappearing after 5seconds)